### PR TITLE
Fixes issue where msguser is None

### DIFF
--- a/slask.py
+++ b/slask.py
@@ -61,19 +61,21 @@ def handle_message(client, event):
         print("event {0} has no user".format(event))
         return
 
-    try:
-        if msguser["name"] == botname or msguser["name"].lower() == "slackbot":
-            return
-    except:
-        print("error occurred when reading message")
-        print("{0}".format(sys.exc_info()[0]))
-        print("{0}".format(traceback.format_exc()))
+    #happens when a new user joins the team
+    #slask doesn't update its list of users
+    #and searching through users returns None
+    if msguser is None:
+        print("msguser is None")
+        return
+
+    if msguser["name"] == botname or msguser["name"].lower() == "slackbot":
         return
 
     text = "\n".join(run_hook("message", event, {"client": client, "config": config, "hooks": hooks}))
 
     if text:
         client.rtm_send_message(event["channel"], text)
+
 
 event_handlers = {
     "message": handle_message


### PR DESCRIPTION
This issue occurs when a new user is added
to the slack team while slask is running.
Slask does not update its list of users and
when this new user generates an event slask
tries to lookup the user in its internal list
of users and gets None. None is never accounted
for in the code and it is always assumed that
the user will always be in the list.
